### PR TITLE
Fix TypeScript error in electricity-analysis page

### DIFF
--- a/src/app/(app)/electricity-analysis/page.tsx
+++ b/src/app/(app)/electricity-analysis/page.tsx
@@ -1,4 +1,3 @@
-
 'use client';
 
 import React, { useState, useMemo, useEffect } from 'react';
@@ -88,7 +87,7 @@ const rawDataString = `SL:no.	Zone	Type 	Muscat Bay Number	Unit Number (Muncipal
 55		SBJ Common Meter		Bank muscat	MISSING_METER	148	72	59	98	88	163
 56		SBJ Common Meter		CIF kitchen	MISSING_METER	16742	15554	16788	16154	14971	18446`.trim();
 
-const extractCategory = (unitName) => {
+const extractCategory = (unitName: string | undefined | null) => {
     if (!unitName) return 'Other';
     const lowerUnitName = unitName.toLowerCase();
     if (lowerUnitName.includes('pumping station')) return 'Pumping Station';


### PR DESCRIPTION
This PR fixes the TypeScript build error that was preventing deployment on Netlify.

## Problem
The build was failing with the error:
```
Type error: Parameter 'unitName' implicitly has an 'any' type.
```

This was happening because TypeScript's strict mode requires all function parameters to have explicit type annotations.

## Solution
Added proper type annotation to the `extractCategory` function parameter:
```typescript
// Before
const extractCategory = (unitName) => {

// After  
const extractCategory = (unitName: string | undefined | null) => {
```

The parameter can be string, undefined, or null based on the guard check in the function.

## Testing
The fix ensures TypeScript compilation will succeed and the Netlify deployment should now work properly.